### PR TITLE
Feature/len remaining

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,14 +4,14 @@
 //!
 //! `RingBuffer` is the initial structure representing ring buffer itself.
 //! Ring buffer can be splitted into pair of `Producer` and `Consumer`.
-//! 
+//!
 //! `Producer` and `Consumer` are used to append/remove elements to/from the ring buffer accordingly. They can be safely transfered between threads.
 //! Operations with `Producer` and `Consumer` are lock-free - they're succeded or failed immediately without blocking or waiting.
-//! 
+//!
 //! Elements can be effectively appended/removed one by one or many at once.
 //! Also data could be loaded/stored directly into/from [`Read`]/[`Write`] instances.
 //! And finally, there are `unsafe` methods allowing thread-safe direct access in place to the inner memory being appended/removed.
-//! 
+//!
 //! [`Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
 //! [`Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 //!
@@ -25,15 +25,15 @@
 //! # fn main() {
 //! let rb = RingBuffer::<i32>::new(2);
 //! let (mut prod, mut cons) = rb.split();
-//! 
+//!
 //! prod.push(0).unwrap();
 //! prod.push(1).unwrap();
 //! assert_eq!(prod.push(2), Err(PushError::Full(2)));
-//! 
+//!
 //! assert_eq!(cons.pop().unwrap(), 0);
-//! 
+//!
 //! prod.push(2).unwrap();
-//! 
+//!
 //! assert_eq!(cons.pop().unwrap(), 1);
 //! assert_eq!(cons.pop().unwrap(), 2);
 //! assert_eq!(cons.pop(), Err(PopError::Empty));
@@ -49,17 +49,17 @@
 //! use std::io::{Read};
 //! use std::thread;
 //! use std::time::{Duration};
-//! 
+//!
 //! use ringbuf::{RingBuffer};
 //! # fn main() {
 //! let rb = RingBuffer::<u8>::new(10);
 //! let (mut prod, mut cons) = rb.split();
-//! 
+//!
 //! let smsg = "The quick brown fox jumps over the lazy dog";
-//! 
+//!
 //! let pjh = thread::spawn(move || {
 //!     println!("-> sending message: '{}'", smsg);
-//! 
+//!
 //!     let zero = [0 as u8];
 //!     let mut bytes = smsg.as_bytes().chain(&zero[..]);
 //!     loop {
@@ -76,13 +76,13 @@
 //!             },
 //!         }
 //!     }
-//! 
+//!
 //!     println!("-> message sent");
 //! });
-//! 
+//!
 //! let cjh = thread::spawn(move || {
 //!     println!("<- receiving message");
-//! 
+//!
 //!     let mut bytes = Vec::<u8>::new();
 //!     loop {
 //!         match cons.write_into(&mut bytes, None) {
@@ -97,17 +97,17 @@
 //!             },
 //!         }
 //!     }
-//! 
+//!
 //!     assert_eq!(bytes.pop().unwrap(), 0);
 //!     let msg = String::from_utf8(bytes).unwrap();
 //!     println!("<- message received: '{}'", msg);
-//! 
+//!
 //!     msg
 //! });
-//! 
+//!
 //! pjh.join().unwrap();
 //! let rmsg = cjh.join().unwrap();
-//! 
+//!
 //! assert_eq!(smsg, rmsg);
 //! # }
 //! ```
@@ -291,7 +291,7 @@ impl<T: Sized> Drop for RingBuffer<T> {
         let head = self.head.load(Ordering::SeqCst);
         let tail = self.tail.load(Ordering::SeqCst);
         let len = data.len();
-        
+
         let slices = if head <= tail {
             (head..tail, 0..0)
         } else {
@@ -327,7 +327,7 @@ impl<T: Sized> Producer<T> {
     pub fn is_full(&self) -> bool {
         self.rb.is_full()
     }
-    
+
     /// Appends an element to the ring buffer.
     /// On failure returns an error containing the element that hasn't beed appended.
     pub fn push(&mut self, elem: T) -> Result<(), PushError<T>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,6 +282,18 @@ impl<T: Sized> RingBuffer<T> {
         let tail = self.tail.load(Ordering::SeqCst);
         (tail + 1) % (self.capacity() + 1) == head
     }
+
+    /// The length of the data in the buffer.
+    pub fn len(&self) -> usize {
+        let head = self.head.load(Ordering::SeqCst);
+        let tail = self.tail.load(Ordering::SeqCst);
+        (tail + 1 - head + self.capacity()) % (self.capacity() + 1)
+    }
+
+    /// The remaining space in the buffer.
+    pub fn remaining(&self) -> usize {
+        self.capacity() - self.len()
+    }
 }
 
 impl<T: Sized> Drop for RingBuffer<T> {
@@ -326,6 +338,16 @@ impl<T: Sized> Producer<T> {
     /// Checks if the ring buffer is full.
     pub fn is_full(&self) -> bool {
         self.rb.is_full()
+    }
+
+    /// The length of the data in the buffer.
+    pub fn len(&self) -> usize {
+        self.rb.len()
+    }
+
+    /// The remaining space in the buffer.
+    pub fn remaining(&self) -> usize {
+        self.rb.remaining()
     }
 
     /// Appends an element to the ring buffer.
@@ -573,6 +595,16 @@ impl<T: Sized> Consumer<T> {
     /// Checks if the ring buffer is full.
     pub fn is_full(&self) -> bool {
         self.rb.is_full()
+    }
+
+    /// The length of the data in the buffer
+    pub fn len(&self) -> usize {
+        self.rb.len()
+    }
+
+    /// The remaining space in the buffer.
+    pub fn remaining(&self) -> usize {
+        self.rb.remaining()
     }
 
     /// Removes first element from the ring buffer and returns it.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -21,7 +21,7 @@ fn split_capacity() {
     let cap = 13;
     let buf = RingBuffer::<i32>::new(cap);
     let (prod, cons) = buf.split();
-    
+
     assert_eq!(prod.capacity(), cap);
     assert_eq!(cons.capacity(), cap);
 }
@@ -30,7 +30,7 @@ fn split_capacity() {
 fn split_threads() {
     let buf = RingBuffer::<i32>::new(10);
     let (prod, cons) = buf.split();
-    
+
     let pjh = thread::spawn(move || {
         let _ = prod;
     });
@@ -48,7 +48,7 @@ fn push() {
     let cap = 2;
     let buf = RingBuffer::<i32>::new(cap);
     let (mut prod, _) = buf.split();
-    
+
 
     assert_eq!(head_tail(&prod.rb), (0, 0));
 
@@ -198,7 +198,7 @@ fn drop() {
         cons.pop().unwrap();
         assert_eq!((ca.get(), cb.get()), (1, 0));
     }
-    
+
     assert_eq!((ca.get(), cb.get()), (1, 1));
 }
 
@@ -321,11 +321,11 @@ fn pop_access() {
 
 
     let vs_11 = (123, 456);
-    
+
     assert_eq!(prod.push(vs_11.0), Ok(()));
     assert_eq!(prod.push(vs_11.1), Ok(()));
     assert_eq!(prod.push(0), Err(PushError::Full(0)));
-    
+
     let pop_fn_11 = |left: &mut [i32], right: &mut [i32]| -> Result<(usize, ()), ()> {
         assert_eq!(left.len(), 1);
         assert_eq!(right.len(), 1);
@@ -769,7 +769,7 @@ fn push_pop_access_message() {
     let (mut prod, mut cons) = buf.split();
 
     let smsg = "The quick brown fox jumps over the lazy dog";
-    
+
     let pjh = thread::spawn(move || {
         let zero = [0 as u8];
         let mut bytes = smsg.as_bytes().chain(&zero[..]);
@@ -842,7 +842,7 @@ fn push_pop_slice_message() {
     let (mut prod, mut cons) = buf.split();
 
     let smsg = "The quick brown fox jumps over the lazy dog";
-    
+
     let pjh = thread::spawn(move || {
         let mut bytes = smsg.as_bytes();
         while bytes.len() > 0 {
@@ -891,7 +891,7 @@ fn read_from_write_into_message() {
     let (mut prod, mut cons) = buf.split();
 
     let smsg = "The quick brown fox jumps over the lazy dog";
-    
+
     let pjh = thread::spawn(move || {
         let zero = [0 as u8];
         let mut bytes = smsg.as_bytes().chain(&zero[..]);
@@ -944,7 +944,7 @@ fn read_write_message() {
     let (mut prod, mut cons) = buf.split();
 
     let smsg = "The quick brown fox jumps over the lazy dog";
-    
+
     let pjh = thread::spawn(move || {
         let mut bytes = smsg.as_bytes();
         while bytes.len() > 0 {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -159,6 +159,45 @@ fn empty_full() {
     assert!(cons.is_full());
 }
 
+#[test]
+fn len_remaining() {
+    let buf = RingBuffer::<i32>::new(2);
+    let (mut prod, mut cons) = buf.split();
+
+    assert_eq!(prod.len(), 0);
+    assert_eq!(cons.len(), 0);
+    assert_eq!(prod.remaining(), 2);
+    assert_eq!(cons.remaining(), 2);
+
+    assert_eq!(prod.push(123), Ok(()));
+
+    assert_eq!(prod.len(), 1);
+    assert_eq!(cons.len(), 1);
+    assert_eq!(prod.remaining(), 1);
+    assert_eq!(cons.remaining(), 1);
+
+    assert_eq!(prod.push(456), Ok(()));
+
+    assert_eq!(prod.len(), 2);
+    assert_eq!(cons.len(), 2);
+    assert_eq!(prod.remaining(), 0);
+    assert_eq!(cons.remaining(), 0);
+
+    assert_eq!(cons.pop(), Ok(123));
+
+    assert_eq!(prod.len(), 1);
+    assert_eq!(cons.len(), 1);
+    assert_eq!(prod.remaining(), 1);
+    assert_eq!(cons.remaining(), 1);
+
+    assert_eq!(cons.pop(), Ok(456));
+
+    assert_eq!(prod.len(), 0);
+    assert_eq!(cons.len(), 0);
+    assert_eq!(prod.remaining(), 2);
+    assert_eq!(cons.remaining(), 2);
+}
+
 #[derive(Debug)]
 struct Dropper<'a> {
     cnt: &'a Cell<i32>,


### PR DESCRIPTION
Add API to get the length of the data in the buffer as well as the remaining capacity.

Hi, thanks for writing this. I wanted to use ringbuf to make an async version that implements AsyncRead/AsyncWrite from the futures library. Main purpose is to allow testing and examples for network libraries cross platform without having to initiate TCP connections. 

For testing it would be handy to be able to verify the amount of data in the buffer. This adds two methods: `len` and `remaining`. I added unit tests for both methods.

My editor automatically removes trailing whitespace, so I though I might as well add it in a separate commit, since it's not much good anyway.