### PR TITLE
Avoid integer overflow on usize with substraction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,7 +287,7 @@ impl<T: Sized> RingBuffer<T> {
     pub fn len(&self) -> usize {
         let head = self.head.load(Ordering::SeqCst);
         let tail = self.tail.load(Ordering::SeqCst);
-        (tail + 1 - head + self.capacity()) % (self.capacity() + 1)
+        (tail + self.capacity() + 1 - head) % (self.capacity() + 1)
     }
 
     /// The remaining space in the buffer.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -196,6 +196,15 @@ fn len_remaining() {
     assert_eq!(cons.len(), 0);
     assert_eq!(prod.remaining(), 2);
     assert_eq!(cons.remaining(), 2);
+
+    // now head is at 2, so tail will be at 0. This caught an overflow error
+    // when tail+1 < head because of the substraction of usize.
+    assert_eq!(prod.push(789), Ok(()));
+
+    assert_eq!(prod.len(), 1);
+    assert_eq!(cons.len(), 1);
+    assert_eq!(prod.remaining(), 1);
+    assert_eq!(cons.remaining(), 1);
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Sorry about this, but I only just discovered this. I didn't pay attention last night that the tests properly verify tail < head, and in debug mode, substracting a usize under zero will panic.

By inversing the order of the operations and adding the capacity first, this should be impossible now.